### PR TITLE
Check whether the Keast connectivity model has the right number of neurons

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -8,4 +8,5 @@ class Config(object):
     SCICRUNCH_API_HOST = os.environ['SCICRUNCH_API_HOST']
     SCICRUNCH_API_KEY = os.environ['SCICRUNCH_API_KEY']
     SCICRUNCH_APINATOMY_HOST = os.environ.get('SCICRUNCH_APINATOMY_HOST', 'https://scicrunch.org/api/1/sparc-scigraph/dynamic/demos/apinat')
+    SCICRUNCH_SPARC_CYPHER = os.environ.get('SCICRUNCH_SPARC_CYPHER', 'http://sparc-data.scicrunch.io:9000/scigraph/cypher/execute')
     SPARC_PENNSIEVE_ORGANISATION_ID = 367

--- a/tests/config.py
+++ b/tests/config.py
@@ -7,5 +7,5 @@ class Config(object):
     PENNSIEVE_API_TOKEN = os.environ['PENNSIEVE_API_TOKEN']
     SCICRUNCH_API_HOST = os.environ['SCICRUNCH_API_HOST']
     SCICRUNCH_API_KEY = os.environ['SCICRUNCH_API_KEY']
-    SCICRUNCH_APINATOMY_HOST = os.environ.get('SCICRUNCH_APINATOMY_HOST', 'http://sparc-data.scicrunch.io:9000/scigraph/dynamic/demos/apinat')
+    SCICRUNCH_APINATOMY_HOST = os.environ.get('SCICRUNCH_APINATOMY_HOST', 'https://scicrunch.org/api/1/sparc-scigraph/dynamic/demos/apinat')
     SPARC_PENNSIEVE_ORGANISATION_ID = 367

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -13,6 +13,22 @@ from tests.config import Config
 
 #===============================================================================
 
+def get_neurons(model_id):
+    # From https://github.com/SciCrunch/sparc-curation/blob/master/docs/queries.org#neru-model-populations
+    # See also https://github.com/SciCrunch/sparc-curation/blob/master/docs/queries.org#neru-model-populations-and-references
+    cypher = """
+        MATCH (start:Ontology {{iri: "{MODEL_ID}"}})
+        <-[:isDefinedBy]-(external:Class)
+        -[:subClassOf*]->(:Class {{iri: "http://uri.interlex.org/tgbugs/uris/readable/NeuronEBM"}}) // FIXME
+        RETURN external
+    """.format(MODEL_ID=model_id)
+    headers = {'accept': 'application/json'}
+    params = {
+        'api_key': Config.SCICRUNCH_API_KEY,
+        'cypherQuery': cypher,
+    }
+    return requests.get(Config.SCICRUNCH_SPARC_CYPHER, headers=headers, params=params)
+
 def get_connectivity(query):
     headers = {'accept': 'application/json'}
     params = {'api_key': Config.SCICRUNCH_API_KEY}
@@ -27,6 +43,13 @@ class ConnectivityTestCase(unittest.TestCase):
         response = get_connectivity('modelList.json')
         self.assertEqual(200, response.status_code)
         assert len(response.json()['nodes']) > 5
+
+    def test_connectivity_neurons(self):
+        connectivity_model = 'https://apinatomy.org/uris/models/keast-bladder'
+        response = get_neurons(connectivity_model)
+        self.assertEqual(200, response.status_code)
+        neurons = response.json()
+        self.assertEqual(len(neurons['nodes']), 20)
 
     def test_connectivity_neuron_group(self):
         neuron_group = 'ilxtr:neuron-type-keast-5'


### PR DESCRIPTION
Something broke in the Keast model in SciCrunch and somehow it's lost 10 neuron groups... This will check that things are as they should be.