### PR TITLE
Fix a response json issue potentially caused by unicode.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests==2.28.1
 algoliasearch==2.6.2
 boto3==1.17.67
+ftfy==6.1.1
 mapknowledge @ https://github.com/AnatomicMaps/map-knowledge/releases/download/v0.13.1/mapknowledge-0.13.1-py3-none-any.whl

--- a/tests/nightly_tests/test_comparison.py
+++ b/tests/nightly_tests/test_comparison.py
@@ -3,10 +3,11 @@ import unittest
 import requests
 
 from algoliasearch.search_client import SearchClient
-
+from ftfy import fix_text
 from urllib.parse import urljoin
 
 from tests.config import Config
+
 
 SCICRUNCH_DOI_AGGREGATION = {
     "from": 0,
@@ -83,7 +84,8 @@ class ComparisonTestCase(unittest.TestCase):
         response = requests.get(urljoin(pennsieve_host, 'datasets'), params=params, headers=headers)
         self.assertEqual(200, response.status_code)
 
-        json_data = json.loads(response.text)
+        fixed_text = fix_text(response.text)
+        json_data = json.loads(fixed_text)
         discover_doi = []
         name_doi_map = {}
         for dataset in json_data['datasets']:


### PR DESCRIPTION
Encounter json decoding issue again. it is potentially an issue with unicode.
The text will now be fixed using an external library before decoding.