### PR TITLE
Add CQ test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # PyCharm
 .idea/
+/external

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ algoliasearch==2.6.2
 boto3==1.17.67
 ftfy==6.1.1
 mapknowledge @ https://github.com/AnatomicMaps/map-knowledge/releases/download/v0.13.1/mapknowledge-0.13.1-py3-none-any.whl
+pytest==6.2.5

--- a/tests/config.py
+++ b/tests/config.py
@@ -16,3 +16,4 @@ class Config(object):
     AWS_KEY=os.environ['AWS_KEY']
     AWS_SECRET=os.environ['AWS_SECRET']
     NEUROLUCIDA_HOST = os.environ.get("NEUROLUCIDA_HOST", "https://sparc.biolucida.net:8081")
+    FLATMAP_ENDPOINT = os.environ.get("FLATMAP_ENDPOINT", "https://mapcore-demo.org/devel/flatmap/v4/")

--- a/tests/cq_tests/test_cq_query_1.py
+++ b/tests/cq_tests/test_cq_query_1.py
@@ -1,0 +1,44 @@
+import pytest
+from tests.slow_tests.overrides.utility import cq_request, assert_valid_query_response, SCKAN_VERSION, MALE_UUID, FEMALE_UUID
+
+base_query = {
+    'query_id': '1',
+    'parameters': [
+        {'column': 'feature_id', 'value': 'UBERON:0004713'} # corpus cavernosum penis
+    ]
+}
+
+def test_sckan():
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': SCKAN_VERSION}]}
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:sparc-nlp/mmset4/3', 'ilxtr:sparc-nlp/mmset4/3a']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=2,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+def test_human_male_map():
+    # Note: 'ilxtr:sparc-nlp/mmset4/3a' having MPG as soma in rat, not expected in human
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': MALE_UUID}]}
+    response = cq_request(query)
+    expected_path_ids = ['ilxtr:sparc-nlp/mmset4/3']
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=1,
+        expected_column_values={'path_id': expected_path_ids}
+    )
+
+def test_human_female_map():
+    # corpus cavernosum penis not expected in female
+    query = {**base_query, 'parameters': base_query['parameters'] + [{'column': 'source_id', 'value': FEMALE_UUID}]}
+    response = cq_request(query)
+    expected_path_ids = []
+    assert_valid_query_response(
+        response,
+        expected_num_keys=2,
+        expected_num_values=0,
+        expected_column_values={'path_id': expected_path_ids}
+    )

--- a/tests/slow_tests/competency_query_tests.py
+++ b/tests/slow_tests/competency_query_tests.py
@@ -2,57 +2,8 @@ import unittest
 import os
 import subprocess
 import shutil
-import requests
 import pytest
-from tests.config import Config
-
-ENDPOINT = Config.FLATMAP_ENDPOINT
-
-FLATMAPS = [
-    'human-flatmap_male',
-    'human-flatmap_female',
-    'rat-flatmap'
-]
-
-TESTING_VARIABLES = {}
-
-def get_variables(key):
-    return TESTING_VARIABLES[key]
-
-def set_variables(endpoint, data):
-    TESTING_VARIABLES["END_POINT"] = endpoint + 'competency/query'
-    for key, value in data.items():
-        if key == 'human-flatmap_male':
-            TESTING_VARIABLES["MALE_UUID"] = value['uuid']
-            TESTING_VARIABLES["SCKAN_VERSION"] = value['knowledge-source']
-        elif key == 'human-flatmap_female':
-            TESTING_VARIABLES["FEMALE_UUID"] = value['uuid']
-        elif key == 'rat-flatmap':
-            TESTING_VARIABLES["RAT_UUID"] = value['uuid']
-
-def get_latest_flatmap(data, scope):
-    latest_flatmap_dict = {}
-    for key, value in data.items():
-        if key not in latest_flatmap_dict and key in scope:
-            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
-            latest_flatmap_dict[key] = stored_maps[0]
-    return latest_flatmap_dict
-
-def get_flatmap_info(endpoint):
-    flatmap_dict = {}
-    flatmap_response = requests.get(endpoint)
-    flatmap_json = flatmap_response.json()
-    for map in flatmap_json:
-        map_id = map.get('id', 'N/A')
-        if map_id not in flatmap_dict:
-            flatmap_dict[map_id] = []
-        info = {
-            'uuid': map.get('uuid', 'N/A'),
-            'created': map.get('created', 'N/A'),
-            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
-        }
-        flatmap_dict[map_id].append(info)
-    return flatmap_dict
+from tests.slow_tests.competency_query_utility import get_flatmap_info, get_latest_flatmap, set_variables
 
 class CompetencyQueryTest(unittest.TestCase):
 
@@ -71,13 +22,13 @@ class CompetencyQueryTest(unittest.TestCase):
             subprocess.run(["git", "-C", repo_path, "pull"], check=True)
         # Replace your modified utility file into place
         shutil.copyfile(
-            "tests/slow_tests/utility.py",
+            "tests/slow_tests/overrides/utility.py",
             "external/flatmap-server/tests/utility.py"
         )
-        flatmap_info = get_flatmap_info(ENDPOINT)
-        latest_flatmap = get_latest_flatmap(flatmap_info, FLATMAPS)
-        set_variables(ENDPOINT, latest_flatmap)
         exit_code = pytest.main(["external/flatmap-server/tests/"])
+        flatmap_info = get_flatmap_info()
+        latest_flatmap = get_latest_flatmap(flatmap_info)
+        set_variables(latest_flatmap)
         print(f"Pytest exit code: {exit_code}")
 
 if __name__ == '__main__':

--- a/tests/slow_tests/competency_query_tests.py
+++ b/tests/slow_tests/competency_query_tests.py
@@ -2,8 +2,57 @@ import unittest
 import os
 import subprocess
 import shutil
+import requests
 import pytest
-from tests.slow_tests.utility import *
+from tests.config import Config
+
+ENDPOINT = Config.FLATMAP_ENDPOINT
+
+FLATMAPS = [
+    'human-flatmap_male',
+    'human-flatmap_female',
+    'rat-flatmap'
+]
+
+TESTING_VARIABLES = {}
+
+def get_variables(key):
+    return TESTING_VARIABLES[key]
+
+def set_variables(endpoint, data):
+    TESTING_VARIABLES["END_POINT"] = endpoint + 'competency/query'
+    for key, value in data.items():
+        if key == 'human-flatmap_male':
+            TESTING_VARIABLES["MALE_UUID"] = value['uuid']
+            TESTING_VARIABLES["SCKAN_VERSION"] = value['knowledge-source']
+        elif key == 'human-flatmap_female':
+            TESTING_VARIABLES["FEMALE_UUID"] = value['uuid']
+        elif key == 'rat-flatmap':
+            TESTING_VARIABLES["RAT_UUID"] = value['uuid']
+
+def get_latest_flatmap(data, scope):
+    latest_flatmap_dict = {}
+    for key, value in data.items():
+        if key not in latest_flatmap_dict and key in scope:
+            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
+            latest_flatmap_dict[key] = stored_maps[0]
+    return latest_flatmap_dict
+
+def get_flatmap_info(endpoint):
+    flatmap_dict = {}
+    flatmap_response = requests.get(endpoint)
+    flatmap_json = flatmap_response.json()
+    for map in flatmap_json:
+        map_id = map.get('id', 'N/A')
+        if map_id not in flatmap_dict:
+            flatmap_dict[map_id] = []
+        info = {
+            'uuid': map.get('uuid', 'N/A'),
+            'created': map.get('created', 'N/A'),
+            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
+        }
+        flatmap_dict[map_id].append(info)
+    return flatmap_dict
 
 class CompetencyQueryTest(unittest.TestCase):
 
@@ -25,9 +74,9 @@ class CompetencyQueryTest(unittest.TestCase):
             "tests/slow_tests/utility.py",
             "external/flatmap-server/tests/utility.py"
         )
-        flatmap_info = get_flatmap_info()
-        latest_flatmap = get_latest_flatmap(flatmap_info)
-        set_variables(latest_flatmap)
+        flatmap_info = get_flatmap_info(ENDPOINT)
+        latest_flatmap = get_latest_flatmap(flatmap_info, FLATMAPS)
+        set_variables(ENDPOINT, latest_flatmap)
         exit_code = pytest.main(["external/flatmap-server/tests/"])
         print(f"Pytest exit code: {exit_code}")
 

--- a/tests/slow_tests/competency_query_tests.py
+++ b/tests/slow_tests/competency_query_tests.py
@@ -1,0 +1,82 @@
+import unittest
+import os
+import subprocess
+import shutil
+import requests
+import pytest
+
+ENDPOINTS = [
+    'https://mapcore-demo.org/staging/flatmap/v1/',
+    'https://mapcore-demo.org/current/flatmap/v3/'
+]
+
+FLATMAPS = [
+    'human-flatmap_male',
+    'human-flatmap_female',
+    'rat-flatmap'
+]
+
+def set_variables(endpoint, data):
+    os.environ["TARGET_END_POINT"] = endpoint + 'competency/query'
+    for key, value in data.items():
+        if key == 'human-flatmap_male':
+            os.environ["LATEST_MALE_UUID"] = value['uuid']
+            os.environ["LATEST_SCKAN_VERSION"] = value['knowledge-source']
+        elif key == 'human-flatmap_female':
+            os.environ["LATEST_FEMALE_UUID"] = value['uuid']
+        elif key == 'rat-flatmap':
+            os.environ["LATEST_RAT_UUID"] = value['uuid']
+
+def get_latest_flatmap(data, scope):
+    latest_flatmap_dict = {}
+    for key, value in data.items():
+        if key not in latest_flatmap_dict and key in scope:
+            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
+            latest_flatmap_dict[key] = stored_maps[0]
+    return latest_flatmap_dict
+
+def get_flatmap_info(endpoint):
+    flatmap_dict = {}
+    flatmap_response = requests.get(endpoint)
+    flatmap_json = flatmap_response.json()
+    for map in flatmap_json:
+        map_id = map.get('id', 'N/A')
+        if map_id not in flatmap_dict:
+            flatmap_dict[map_id] = []
+        info = {
+            'uuid': map.get('uuid', 'N/A'),
+            'created': map.get('created', 'N/A'),
+            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
+        }
+        flatmap_dict[map_id].append(info)
+    return flatmap_dict
+
+class CompetencyQueryTest(unittest.TestCase):
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+
+    def test_competency_query(self):
+        # Clone the repo into external/flatmap-server
+        repo_path = "external/flatmap-server"
+        if not os.path.exists(repo_path):
+            subprocess.run(
+                ["git", "clone", "https://github.com/AnatomicMaps/flatmap-server.git", repo_path],
+                check=True
+            )
+        else:
+            subprocess.run(["git", "-C", repo_path, "pull"], check=True)
+        # Replace your modified utility file into place
+        shutil.copyfile(
+            "tests/slow_tests/utility.py",
+            "external/flatmap-server/tests/utility.py"
+        )
+        for endpoint in ENDPOINTS:
+            flatmap_info = get_flatmap_info(endpoint)
+            latest_flatmap = get_latest_flatmap(flatmap_info, FLATMAPS)
+            set_variables(endpoint, latest_flatmap)
+            # Run all tests inside their repo
+            subprocess.run(["pytest", "external/flatmap-server/tests/"], env=os.environ)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/slow_tests/competency_query_tests.py
+++ b/tests/slow_tests/competency_query_tests.py
@@ -2,57 +2,8 @@ import unittest
 import os
 import subprocess
 import shutil
-import requests
 import pytest
-from tests.config import Config
-
-ENDPOINT = Config.FLATMAP_ENDPOINT
-
-FLATMAPS = [
-    'human-flatmap_male',
-    'human-flatmap_female',
-    'rat-flatmap'
-]
-
-TESTING_VARIABLES = {}
-
-def get_variables(key):
-    return TESTING_VARIABLES[key]
-
-def set_variables(endpoint, data):
-    TESTING_VARIABLES["END_POINT"] = endpoint + 'competency/query'
-    for key, value in data.items():
-        if key == 'human-flatmap_male':
-            TESTING_VARIABLES["MALE_UUID"] = value['uuid']
-            TESTING_VARIABLES["SCKAN_VERSION"] = value['knowledge-source']
-        elif key == 'human-flatmap_female':
-            TESTING_VARIABLES["FEMALE_UUID"] = value['uuid']
-        elif key == 'rat-flatmap':
-            TESTING_VARIABLES["RAT_UUID"] = value['uuid']
-
-def get_latest_flatmap(data, scope):
-    latest_flatmap_dict = {}
-    for key, value in data.items():
-        if key not in latest_flatmap_dict and key in scope:
-            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
-            latest_flatmap_dict[key] = stored_maps[0]
-    return latest_flatmap_dict
-
-def get_flatmap_info(endpoint):
-    flatmap_dict = {}
-    flatmap_response = requests.get(endpoint)
-    flatmap_json = flatmap_response.json()
-    for map in flatmap_json:
-        map_id = map.get('id', 'N/A')
-        if map_id not in flatmap_dict:
-            flatmap_dict[map_id] = []
-        info = {
-            'uuid': map.get('uuid', 'N/A'),
-            'created': map.get('created', 'N/A'),
-            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
-        }
-        flatmap_dict[map_id].append(info)
-    return flatmap_dict
+from tests.slow_tests.utility import *
 
 class CompetencyQueryTest(unittest.TestCase):
 
@@ -74,9 +25,9 @@ class CompetencyQueryTest(unittest.TestCase):
             "tests/slow_tests/utility.py",
             "external/flatmap-server/tests/utility.py"
         )
-        flatmap_info = get_flatmap_info(ENDPOINT)
-        latest_flatmap = get_latest_flatmap(flatmap_info, FLATMAPS)
-        set_variables(ENDPOINT, latest_flatmap)
+        flatmap_info = get_flatmap_info()
+        latest_flatmap = get_latest_flatmap(flatmap_info)
+        set_variables(latest_flatmap)
         exit_code = pytest.main(["external/flatmap-server/tests/"])
         print(f"Pytest exit code: {exit_code}")
 

--- a/tests/slow_tests/competency_query_tests.py
+++ b/tests/slow_tests/competency_query_tests.py
@@ -25,10 +25,10 @@ class CompetencyQueryTest(unittest.TestCase):
             "tests/slow_tests/overrides/utility.py",
             "external/flatmap-server/tests/utility.py"
         )
-        exit_code = pytest.main(["external/flatmap-server/tests/"])
         flatmap_info = get_flatmap_info()
         latest_flatmap = get_latest_flatmap(flatmap_info)
         set_variables(latest_flatmap)
+        exit_code = pytest.main(["tests/cq_tests/", "external/flatmap-server/tests/"])
         print(f"Pytest exit code: {exit_code}")
 
 if __name__ == '__main__':

--- a/tests/slow_tests/competency_query_tests.py
+++ b/tests/slow_tests/competency_query_tests.py
@@ -4,11 +4,9 @@ import subprocess
 import shutil
 import requests
 import pytest
+from tests.config import Config
 
-ENDPOINTS = [
-    'https://mapcore-demo.org/staging/flatmap/v1/',
-    'https://mapcore-demo.org/current/flatmap/v3/'
-]
+ENDPOINT = Config.FLATMAP_ENDPOINT
 
 FLATMAPS = [
     'human-flatmap_male',
@@ -16,16 +14,21 @@ FLATMAPS = [
     'rat-flatmap'
 ]
 
+TESTING_VARIABLES = {}
+
+def get_variables(key):
+    return TESTING_VARIABLES[key]
+
 def set_variables(endpoint, data):
-    os.environ["TARGET_END_POINT"] = endpoint + 'competency/query'
+    TESTING_VARIABLES["END_POINT"] = endpoint + 'competency/query'
     for key, value in data.items():
         if key == 'human-flatmap_male':
-            os.environ["LATEST_MALE_UUID"] = value['uuid']
-            os.environ["LATEST_SCKAN_VERSION"] = value['knowledge-source']
+            TESTING_VARIABLES["MALE_UUID"] = value['uuid']
+            TESTING_VARIABLES["SCKAN_VERSION"] = value['knowledge-source']
         elif key == 'human-flatmap_female':
-            os.environ["LATEST_FEMALE_UUID"] = value['uuid']
+            TESTING_VARIABLES["FEMALE_UUID"] = value['uuid']
         elif key == 'rat-flatmap':
-            os.environ["LATEST_RAT_UUID"] = value['uuid']
+            TESTING_VARIABLES["RAT_UUID"] = value['uuid']
 
 def get_latest_flatmap(data, scope):
     latest_flatmap_dict = {}
@@ -71,12 +74,11 @@ class CompetencyQueryTest(unittest.TestCase):
             "tests/slow_tests/utility.py",
             "external/flatmap-server/tests/utility.py"
         )
-        for endpoint in ENDPOINTS:
-            flatmap_info = get_flatmap_info(endpoint)
-            latest_flatmap = get_latest_flatmap(flatmap_info, FLATMAPS)
-            set_variables(endpoint, latest_flatmap)
-            # Run all tests inside their repo
-            subprocess.run(["pytest", "external/flatmap-server/tests/"], env=os.environ)
+        flatmap_info = get_flatmap_info(ENDPOINT)
+        latest_flatmap = get_latest_flatmap(flatmap_info, FLATMAPS)
+        set_variables(ENDPOINT, latest_flatmap)
+        exit_code = pytest.main(["external/flatmap-server/tests/"])
+        print(f"Pytest exit code: {exit_code}")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/slow_tests/competency_query_utility.py
+++ b/tests/slow_tests/competency_query_utility.py
@@ -1,0 +1,50 @@
+import requests
+from tests.config import Config
+
+FLATMAP_ENDPOINT = Config.FLATMAP_ENDPOINT
+
+FLATMAPS = [
+    'human-flatmap_male',
+    'human-flatmap_female',
+    'rat-flatmap'
+]
+
+TESTING_VARIABLES = {}
+
+def get_variables(key):
+    return TESTING_VARIABLES[key]
+
+def set_variables(data):
+    TESTING_VARIABLES["END_POINT"] = FLATMAP_ENDPOINT + 'competency/query'
+    for key, value in data.items():
+        if key == 'human-flatmap_male':
+            TESTING_VARIABLES["MALE_UUID"] = value['uuid']
+            TESTING_VARIABLES["SCKAN_VERSION"] = value['knowledge-source']
+        elif key == 'human-flatmap_female':
+            TESTING_VARIABLES["FEMALE_UUID"] = value['uuid']
+        elif key == 'rat-flatmap':
+            TESTING_VARIABLES["RAT_UUID"] = value['uuid']
+
+def get_latest_flatmap(data):
+    latest_flatmap_dict = {}
+    for key, value in data.items():
+        if key not in latest_flatmap_dict and key in FLATMAPS:
+            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
+            latest_flatmap_dict[key] = stored_maps[0]
+    return latest_flatmap_dict
+
+def get_flatmap_info():
+    flatmap_dict = {}
+    flatmap_response = requests.get(FLATMAP_ENDPOINT)
+    flatmap_json = flatmap_response.json()
+    for map in flatmap_json:
+        map_id = map.get('id', 'N/A')
+        if map_id not in flatmap_dict:
+            flatmap_dict[map_id] = []
+        info = {
+            'uuid': map.get('uuid', 'N/A'),
+            'created': map.get('created', 'N/A'),
+            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
+        }
+        flatmap_dict[map_id].append(info)
+    return flatmap_dict

--- a/tests/slow_tests/overrides/utility.py
+++ b/tests/slow_tests/overrides/utility.py
@@ -2,7 +2,7 @@ import os
 import sys
 import requests
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
-from tests.slow_tests.competency_query_tests import get_variables
+from tests.slow_tests.competency_query_utility import get_variables
 
 END_POINT = get_variables('END_POINT')
 HEADERS = {'Content-Type': 'application/json'}

--- a/tests/slow_tests/utility.py
+++ b/tests/slow_tests/utility.py
@@ -1,0 +1,56 @@
+import os
+import requests
+
+END_POINT = os.environ.get("TARGET_END_POINT")
+HEADERS = {'Content-Type': 'application/json'}
+
+MALE_UUID = os.environ.get("LATEST_MALE_UUID")
+FEMALE_UUID = os.environ.get("LATEST_FEMALE_UUID")
+RAT_UUID = os.environ.get("LATEST_RAT_UUID")
+SCKAN_VERSION = os.environ.get("LATEST_SCKAN_VERSION")
+
+def cq_request(query: dict):
+    response = requests.post(END_POINT, json=query, headers=HEADERS)
+    return response
+
+def assert_valid_query_response(
+    response,
+    expected_num_keys=None,
+    expected_num_values=None,
+    expected_column_values=None,
+    expected_rows=None
+):
+    assert response.status_code in (200, 201), f'Unexpected status code: {response.status_code}'
+    json_response = response.json()
+
+    results = json_response.get('results', {})
+    keys = results.get('keys', [])
+    values = results.get('values', [])
+
+    if expected_num_keys:
+        assert len(keys) == expected_num_keys, f"Expected {expected_num_keys} keys but got {len(keys)}"
+
+    if expected_num_values:
+        assert len(values) == expected_num_values, f"Expected {expected_num_values} value rows but got {len(values)}"
+
+    if expected_column_values:
+        for col, expected_values in expected_column_values.items():
+            assert col in keys, f"Column '{col}' not found in result keys"
+            idx = keys.index(col)
+            actual_values = [
+                tuple(row[idx]) if isinstance(row[idx], list) else row[idx]
+                for row in values
+            ]
+            expected_values = [
+                tuple(value) if isinstance(value, list) else value
+                for value in expected_values
+            ]
+            assert set(actual_values) == set(expected_values), (
+                f"Expected values in column '{col}' to be {expected_values}, but got {actual_values}"
+            )
+
+    if expected_rows:
+        for row in expected_rows:
+            assert any(
+                all(item in value for item in row) for value in values
+            ), f"Missing expected row: {row}"

--- a/tests/slow_tests/utility.py
+++ b/tests/slow_tests/utility.py
@@ -1,55 +1,16 @@
+import os
+import sys
 import requests
-from tests.config import Config
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+from tests.slow_tests.competency_query_tests import get_variables
 
-FLATMAP_ENDPOINT = Config.FLATMAP_ENDPOINT
-FLATMAPS = [
-    'human-flatmap_male',
-    'human-flatmap_female',
-    'rat-flatmap'
-]
-
-END_POINT = FLATMAP_ENDPOINT + 'competency/query'
+END_POINT = get_variables('END_POINT')
 HEADERS = {'Content-Type': 'application/json'}
 
-MALE_UUID = '2b76d336-5c56-55e3-ab1e-795d6c63f9c1'
-FEMALE_UUID = '91359a0f-9e32-5309-b365-145d9956817d'
-RAT_UUID = 'fb6d0345-cb70-5c7e-893c-d744a6313c95'
-SCKAN_VERSION = 'sckan-2024-09-21'
-
-def set_variables(data):
-    global MALE_UUID, FEMALE_UUID, RAT_UUID, SCKAN_VERSION
-    for key, value in data.items():
-        if key == 'human-flatmap_male':
-            MALE_UUID = value['uuid']
-            SCKAN_VERSION = value['knowledge-source']
-        elif key == 'human-flatmap_female':
-            FEMALE_UUID = value['uuid']
-        elif key == 'rat-flatmap':
-            RAT_UUID = value['uuid']
-
-def get_latest_flatmap(data):
-    latest_flatmap_dict = {}
-    for key, value in data.items():
-        if key not in latest_flatmap_dict and key in FLATMAPS:
-            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
-            latest_flatmap_dict[key] = stored_maps[0]
-    return latest_flatmap_dict
-
-def get_flatmap_info():
-    flatmap_dict = {}
-    flatmap_response = requests.get(FLATMAP_ENDPOINT)
-    flatmap_json = flatmap_response.json()
-    for map in flatmap_json:
-        map_id = map.get('id', 'N/A')
-        if map_id not in flatmap_dict:
-            flatmap_dict[map_id] = []
-        info = {
-            'uuid': map.get('uuid', 'N/A'),
-            'created': map.get('created', 'N/A'),
-            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
-        }
-        flatmap_dict[map_id].append(info)
-    return flatmap_dict
+MALE_UUID = get_variables('MALE_UUID')
+FEMALE_UUID = get_variables('FEMALE_UUID')
+RAT_UUID = get_variables('RAT_UUID')
+SCKAN_VERSION = get_variables('SCKAN_VERSION')
 
 def cq_request(query: dict):
     response = requests.post(END_POINT, json=query, headers=HEADERS)

--- a/tests/slow_tests/utility.py
+++ b/tests/slow_tests/utility.py
@@ -1,16 +1,55 @@
-import os
-import sys
 import requests
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
-from tests.slow_tests.competency_query_tests import get_variables
+from tests.config import Config
 
-END_POINT = get_variables('END_POINT')
+FLATMAP_ENDPOINT = Config.FLATMAP_ENDPOINT
+FLATMAPS = [
+    'human-flatmap_male',
+    'human-flatmap_female',
+    'rat-flatmap'
+]
+
+END_POINT = FLATMAP_ENDPOINT + 'competency/query'
 HEADERS = {'Content-Type': 'application/json'}
 
-MALE_UUID = get_variables('MALE_UUID')
-FEMALE_UUID = get_variables('FEMALE_UUID')
-RAT_UUID = get_variables('RAT_UUID')
-SCKAN_VERSION = get_variables('SCKAN_VERSION')
+MALE_UUID = '2b76d336-5c56-55e3-ab1e-795d6c63f9c1'
+FEMALE_UUID = '91359a0f-9e32-5309-b365-145d9956817d'
+RAT_UUID = 'fb6d0345-cb70-5c7e-893c-d744a6313c95'
+SCKAN_VERSION = 'sckan-2024-09-21'
+
+def set_variables(data):
+    global MALE_UUID, FEMALE_UUID, RAT_UUID, SCKAN_VERSION
+    for key, value in data.items():
+        if key == 'human-flatmap_male':
+            MALE_UUID = value['uuid']
+            SCKAN_VERSION = value['knowledge-source']
+        elif key == 'human-flatmap_female':
+            FEMALE_UUID = value['uuid']
+        elif key == 'rat-flatmap':
+            RAT_UUID = value['uuid']
+
+def get_latest_flatmap(data):
+    latest_flatmap_dict = {}
+    for key, value in data.items():
+        if key not in latest_flatmap_dict and key in FLATMAPS:
+            stored_maps = sorted(value, key=lambda x: x["created"], reverse=True)
+            latest_flatmap_dict[key] = stored_maps[0]
+    return latest_flatmap_dict
+
+def get_flatmap_info():
+    flatmap_dict = {}
+    flatmap_response = requests.get(FLATMAP_ENDPOINT)
+    flatmap_json = flatmap_response.json()
+    for map in flatmap_json:
+        map_id = map.get('id', 'N/A')
+        if map_id not in flatmap_dict:
+            flatmap_dict[map_id] = []
+        info = {
+            'uuid': map.get('uuid', 'N/A'),
+            'created': map.get('created', 'N/A'),
+            'knowledge-source': map.get('sckan', {}).get('knowledge-source', 'N/A')
+        }
+        flatmap_dict[map_id].append(info)
+    return flatmap_dict
 
 def cq_request(query: dict):
     response = requests.post(END_POINT, json=query, headers=HEADERS)

--- a/tests/slow_tests/utility.py
+++ b/tests/slow_tests/utility.py
@@ -1,13 +1,16 @@
 import os
+import sys
 import requests
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+from tests.slow_tests.competency_query_tests import get_variables
 
-END_POINT = os.environ.get("TARGET_END_POINT")
+END_POINT = get_variables('END_POINT')
 HEADERS = {'Content-Type': 'application/json'}
 
-MALE_UUID = os.environ.get("LATEST_MALE_UUID")
-FEMALE_UUID = os.environ.get("LATEST_FEMALE_UUID")
-RAT_UUID = os.environ.get("LATEST_RAT_UUID")
-SCKAN_VERSION = os.environ.get("LATEST_SCKAN_VERSION")
+MALE_UUID = get_variables('MALE_UUID')
+FEMALE_UUID = get_variables('FEMALE_UUID')
+RAT_UUID = get_variables('RAT_UUID')
+SCKAN_VERSION = get_variables('SCKAN_VERSION')
 
 def cq_request(query: dict):
     response = requests.post(END_POINT, json=query, headers=HEADERS)


### PR DESCRIPTION
- `external` folder contains the external repos pulled from GitHub (run external tests directly to make sure default test cases are always up-to-date during scheduled testing)
- `cq_tests` folder will be the place to add customised local CQ tests
- `overrides` folder contains the replacement files that support external tests run with local variables
- `competency_query_tests.py` is the trigger to pull external tests, prepare and run both types of CQ tests using pytest
- `competency_query_utility.py` contains the methods/variables to support either local tests or external tests

<img width="259" height="643" alt="Screenshot 2025-08-26 at 9 26 08 AM" src="https://github.com/user-attachments/assets/45f32138-b004-40f5-9e69-d5770600136f" />
